### PR TITLE
modify: setup.py - install required params

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,10 @@ setup(
     url='http://github.com/actmd/elementium/',
     license='Apache Software License',
     author='Patrick R. Schmid',
-    install_requires=[],
+    install_requires=[
+      'selenium==2.48.0',
+      'six==1.10.0',
+    ],
     author_email='prschmid@act.md',
     description=description,
     long_description=long_description,


### PR DESCRIPTION
When elementium is installed as a package the requirements aren't installed/checked (only setup.py is valid then, requirements.txt is ignored).

I found it a hard way, as six==1.11.0 throws a nasty error.