### PR TITLE
add an arguments parameter to execute_script

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,22 @@ Basically all methods that are part of the `SeElements` object will be automatic
 
 (Look at the code for more detail.)
 
+### Executing JavaScript code
+
+#### Executing code with no arguments
+
+```python
+se.execute_script(script="alert('Executing some JS code')", ttl=10)
+```
+
+#### Execute Javascript code on a specific element
+```python
+# Draw a border around an element to highlight it
+input_field = se.find("input")
+script = "arguments[0].style.border='5px solid #6bf442'"
+# input_field is a collection of elements so you need to get the first one
+se.execute_script(script=script, arguments=input_field.item, ttl=10) 
+```
 
 ### Making assertions
 

--- a/elementium/drivers/se.py
+++ b/elementium/drivers/se.py
@@ -536,10 +536,11 @@ class SeElements(Elements, Browser):
         return self.browser.current_url
 
     def execute_script(
-            self, script, callback=None, asynchronous=False, ttl=None):
+            self, script, arguments = None, callback=None, asynchronous=False, ttl=None):
         """Execute arbitrary JavaScript
 
         :param script: The JavaScript to execute
+        :param arguments: Arguments to be passed to the script
         :param callback: A function to execute with the results of the script.
                          This function should take a single parameter, the
                          results from the script.
@@ -553,7 +554,7 @@ class SeElements(Elements, Browser):
             raise NotImplementedError(
                 "Can't perform asynchronous scripts yet. Sorry.")
         results = self.retried(
-            lambda: self.browser.execute_script(script), update=False)
+            lambda: self.browser.execute_script(script, arguments), update=False)
         if not callback:
             return results
         else:


### PR DESCRIPTION
Fix for https://github.com/actmd/elementium/issues/12: 
- Add an argument parameter to send to the script for parity with the default Selenium implementation.
- Document the usage of the excute_script method in the ReadMe
 