### PR TITLE
Changed call MutableSequence

### DIFF
--- a/elementium/elements.py
+++ b/elementium/elements.py
@@ -114,7 +114,7 @@ class ElementsIterator(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Elements(collections.MutableSequence):
+class Elements(collections.abc.MutableSequence):
     """The abstract base class for a list of web elements"""
 
     def __init__(self, browser, context=None, fn=None, config=None, lazy=None):


### PR DESCRIPTION

When upgrading to python 3.10, elementium stops working at all, this small change will make it work again, as well as remove the warning on pyhton3.9